### PR TITLE
Update meganavv8.resource.js - expected string, got object

### DIFF
--- a/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
+++ b/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
@@ -2,7 +2,11 @@ angular.module("umbraco.resources").factory("meganavV8Resource", function ($http
     return {
         getById: function (id, culture) {
 
+<<<<<<< HEAD
             return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + (typeof culture === 'string' ? culture : culture.cultureName))
+=======
+            return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + culture)
+>>>>>>> parent of c5615d1... Update meganavv8.resource.js - expected string, got object
                 .then(function (response) {
                     var item = response.data;
                     item.icon = iconHelper.convertFromLegacyIcon(item.icon);

--- a/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
+++ b/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
@@ -2,11 +2,7 @@ angular.module("umbraco.resources").factory("meganavV8Resource", function ($http
     return {
         getById: function (id, culture) {
 
-<<<<<<< HEAD
             return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + (typeof culture === 'string' ? culture : culture.cultureName))
-=======
-            return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + culture)
->>>>>>> parent of c5615d1... Update meganavv8.resource.js - expected string, got object
                 .then(function (response) {
                     var item = response.data;
                     item.icon = iconHelper.convertFromLegacyIcon(item.icon);

--- a/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
+++ b/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
@@ -2,7 +2,7 @@
     return {
         getById: function (id, culture) {
 
-            return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + culture)
+            return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + culture.cultureName)
                 .then(function (response) {
                     var item = response.data;
                     item.icon = iconHelper.convertFromLegacyIcon(item.icon);

--- a/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
+++ b/src/AaronSadler.MegaNavV8.Web/Web/UI/App_Plugins/MeganavV8/Js/meganavv8.resource.js
@@ -1,8 +1,8 @@
-﻿angular.module("umbraco.resources").factory("meganavV8Resource", function ($http, iconHelper) {
+angular.module("umbraco.resources").factory("meganavV8Resource", function ($http, iconHelper) {
     return {
         getById: function (id, culture) {
 
-            return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + culture.cultureName)
+            return $http.get("backoffice/MeganavV8/MeganavV8EntityApi/GetById?id=" + id + "&culture=" + (typeof culture === 'string' ? culture : culture.cultureName))
                 .then(function (response) {
                     var item = response.data;
                     item.icon = iconHelper.convertFromLegacyIcon(item.icon);


### PR DESCRIPTION
On a multilingual site, `culture` is an object and the method needs a string. 

If you select an Umbraco node when creating a meganav menu item it will return a url of '#'. Modifying the line to include the property `cultureName` fixes the issue and meganav returns the proper url.